### PR TITLE
fixed typo in small_words function

### DIFF
--- a/Fixme.py
+++ b/Fixme.py
@@ -41,7 +41,7 @@ def threes(n):
 
 def small_words(text):
     '''
-    Returns a list of all words in the input text that are less than 4 characters long.
+    Returns a list of all words in the input text that are less than 5 characters long.
 
     HINT:
     Recall that text.split() converts the text variable into a list of words.


### PR DESCRIPTION
The docstring for the small_words function says that it should return words that are less than 4 characters long, however, both the examples in the docstring and the actual tests for the function allow for words that are 4 characters long or less. Thus this typo fixes the docstring by saying the small_words function returns words that are less than 5 characters long. 